### PR TITLE
Add linux platform for heroku deploy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.12.0-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.0-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -193,6 +195,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
Adds the x86_64-linux platform in order to deploy to heroku. 