### PR TITLE
Add required js setup for graphiql interface

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link graphiql/rails/application.css
+//= link graphiql/rails/application.js

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ require "action_mailer/railtie"
 # require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
-# require "sprockets/railtie"
+require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
## Summary
The `additional-graphiql-setup` branch was required to resolve an issue. The issue happened when I tried to go to the localhost3000/graphiql endpoint. The screen said "Loading...." without resolving. After some research, there were a couple of additional files and settings required to use the graphiql interface. 