### PR TITLE
Add api status check query

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,14 +4,10 @@ module Types
     include GraphQL::Types::Relay::HasNodeField
     include GraphQL::Types::Relay::HasNodesField
 
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
-
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+    field :status, String, null: false,
+      description: "A basic status check to make sure the API and graphiql is working."
+    def status
+      "OK"
     end
   end
 end


### PR DESCRIPTION
## Summary
The `health-check` branch adds the ability to query the API to make sure that it is running properly. The API should respond "OK" when using the "status" in graphiql. 

Figure 1. Status query on graphiql. 
<img width="305" alt="healthquery" src="https://user-images.githubusercontent.com/43938783/128082925-12535011-487b-4372-84d3-9382663cbdf0.png">

Figure 2. Status query response. 
<img width="228" alt="healthqueryresponse" src="https://user-images.githubusercontent.com/43938783/128082996-acf0cb0c-1d90-46e6-b4f8-c88415d138f9.png">
