### PR TITLE
Add additional config settings for heroku to access graphiql assets

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,3 @@
+if Rails.env.development?
+  Rails.application.config.assets.precompile += %w[graphiql/rails/application.js graphiql/rails/application.css]
+end


### PR DESCRIPTION
## Summary
The `config-assets-heroku` branch adds an asset file in the config folder for heroku to access the graphiql assets during deployment. 