### PR TITLE
Add graphiql for production env

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  if Rails.env.development?
+  if Rails.env.development? || Rails.env.production?
     mount GraphiQL::Rails::Engine, at: 'graphiql', graphql_path: "graphql#execute"
   end
   


### PR DESCRIPTION
## Summary
The `production-graphiql-routing` adds the ability to mount graphiql when the env=production. This will be used when the app is deployed to heroku. 