### PR TITLE
Add todo type

### DIFF
--- a/app/graphql/types/todo_type.rb
+++ b/app/graphql/types/todo_type.rb
@@ -1,0 +1,11 @@
+module Types
+  class TodoType < Types::BaseObject
+    field :id, ID, null: false
+    field :title, String, null: false
+    field :description, String, null: true
+    field :completed, Boolean, null: false
+    field :author, String, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/spec/graphql/types/todo_type_spec.rb
+++ b/spec/graphql/types/todo_type_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe Types::TodoType do
+  set_graphql_type
+
+  it "has the correct field types" do
+    expect(subject.fields["id"].type.to_type_signature).to eq("ID!")
+    expect(subject.fields["title"].type.to_type_signature).to eq("String!")
+    expect(subject.fields["description"].type.to_type_signature).to eq("String")
+    expect(subject.fields["completed"].type.to_type_signature).to eq("Boolean!")
+    expect(subject.fields["author"].type.to_type_signature).to eq("String!")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,11 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  def set_graphql_type
+    let(:subject) do
+      described_class
+    end
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
## Summary
The `todo-graphql-object` branch adds the todo type with the matching fields from the Todo rails model. 