### PR TITLE
Add create todo mutation

### DIFF
--- a/app/graphql/mutations/create_todo.rb
+++ b/app/graphql/mutations/create_todo.rb
@@ -1,0 +1,25 @@
+class Mutations::CreateTodo < Mutations::BaseMutation
+  null true
+  argument :title, String, required: true
+  argument :description, String, required: false
+  argument :completed, Boolean, required: true
+  argument :author, String, required: true
+
+  field :todo, Types::TodoType, null: false
+  field :errors, [String], null: false
+
+  def resolve(title:, description:, completed:, author:)
+    todo = Todo.new(title: title, description: description, completed: completed, author: author)
+    if todo.save
+      {
+        todo: todo,
+        errors: []
+      }
+    else
+      {
+        todo: nil,
+        errors: todo.errors.full_messages
+      }
+  end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,10 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
+    field :create_todo, mutation: Mutations::CreateTodo,
+     description: "Adds new todo"
   end
-end
+end 

--- a/spec/graphql/mutations/create_todo_spec.rb
+++ b/spec/graphql/mutations/create_todo_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+module Mutations
+  RSpec.describe CreateTodo, type: :request do
+    describe ".resolve" do
+      context "when valid todo parameters are given" do
+        it "creates a todo" do
+          query = <<~GQL
+      mutation{
+        createTodo(input:{
+          title: "FooBar",
+          description: "Lorem Ipsum.",
+          completed: false,
+          author: "Bill Murray"
+        }) {
+          todo {
+            id,
+            title,
+            description,
+            completed,
+            author
+          }
+          errors
+        }
+      }
+      GQL
+
+          expect { post "/graphql", params: {query: query} }.to change(Todo, :count).by(1)
+          actual_todo = json["data"]["createTodo"]["todo"]
+
+          expect(response).to have_http_status(200)
+          expect(actual_todo["title"]).to eq("FooBar")
+          expect(actual_todo["description"]).to eq("Lorem Ipsum.")
+          expect(actual_todo["completed"]).to eq(false)
+          expect(actual_todo["author"]).to eq("Bill Murray")
+        end
+
+        it "creates a todo with a null description" do
+          query = <<~GQL
+      mutation{
+        createTodo(input:{
+          title: "Foo",
+          description: null,
+          completed: true,
+          author: "Adam Sandler"
+        }) {
+          todo {
+            id,
+            title,
+            description,
+            completed,
+            author
+          }
+          errors
+        }
+      }
+      GQL
+
+          expect { post "/graphql", params: {query: query} }.to change(Todo, :count).by(1)
+          actual_todo = json["data"]["createTodo"]["todo"]
+
+          expect(response).to have_http_status(200)
+          expect(actual_todo["title"]).to eq("Foo")
+          expect(actual_todo["description"]).to eq(nil)
+          expect(actual_todo["completed"]).to eq(true)
+          expect(actual_todo["author"]).to eq("Adam Sandler")
+        end
+      end
+
+      context "when required attributes are not given" do
+        it "does not create a todo and returns an error" do
+          query = <<~GQL
+      mutation{
+        createTodo(input:{
+          title: "",
+          description: "Lorem Ipsum.",
+          completed: true,
+          author: "Lisa Kudrow"
+        }) {
+          todo {
+            id,
+            title,
+            description,
+            completed,
+            author
+          }
+          errors
+        }
+      }
+      GQL
+
+          expect { post "/graphql", params: {query: query} }.to change(Todo, :count).by(0)
+
+          expect(response).to have_http_status(200)
+          expect(json["createTodo"]).to eq(nil)
+          expect(json["errors"][0]["message"]).to eq("Cannot return null for non-nullable field CreateTodoPayload.todo")
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,14 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
-require "database_cleaner"
 ENV["RAILS_ENV"] ||= "test"
+
 require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require "rspec/rails"
+
 # Add additional requires below this line. Rails is not loaded until this point!
+require "database_cleaner"
+require "rspec/rails"
 
 # configure shoulda matchers to use rspec as the test framework and full matcher libraries for rails
 Shoulda::Matchers.configure do |config|
@@ -29,7 +31,7 @@ end
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -45,6 +47,9 @@ RSpec.configure do |config|
 
   # set up factory bot
   config.include FactoryBot::Syntax::Methods
+
+  # include spec_helper_json_parser
+  config.include RequestSpecHelper, type: :request
 
   # set up database cleaner
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.

--- a/spec/support/request_helper_spec.rb
+++ b/spec/support/request_helper_spec.rb
@@ -1,0 +1,5 @@
+module RequestSpecHelper
+  def json
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
## Summary
The `create-todo-mutation` branch adds the ability for the user to add a new todo to the API. 