### PR TITLE
Remove created_at and updated_at fields from todo type

### DIFF
--- a/app/graphql/types/todo_type.rb
+++ b/app/graphql/types/todo_type.rb
@@ -5,7 +5,5 @@ module Types
     field :description, String, null: true
     field :completed, Boolean, null: false
     field :author, String, null: false
-    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end
 end


### PR DESCRIPTION
## Summary
Fixes overexposing database data by removing the created_at and updated_at fields from the todo type. A user can no longer request those fields in the response. 