### PR TITLE
Add default values for description and completed fields

### DIFF
--- a/app/graphql/mutations/create_todo.rb
+++ b/app/graphql/mutations/create_todo.rb
@@ -2,13 +2,13 @@ class Mutations::CreateTodo < Mutations::BaseMutation
   null true
   argument :title, String, required: true
   argument :description, String, required: false
-  argument :completed, Boolean, required: true
+  argument :completed, Boolean, required: false
   argument :author, String, required: true
 
   field :todo, Types::TodoType, null: false
   field :errors, [String], null: false
 
-  def resolve(title:, description:, completed:, author:)
+  def resolve(title:, description: nil, completed: false, author:)
     todo = Todo.new(title: title, description: description, completed: completed, author: author)
     if todo.save
       {

--- a/spec/graphql/mutations/create_todo_spec.rb
+++ b/spec/graphql/mutations/create_todo_spec.rb
@@ -35,14 +35,13 @@ module Mutations
           expect(actual_todo["author"]).to eq("Bill Murray")
         end
 
-        it "creates a todo with a null description" do
+        it "creates a todo without a provided description" do
           query = <<~GQL
       mutation{
         createTodo(input:{
-          title: "Foo",
-          description: null,
+          title: "Tie my shoes"
           completed: true,
-          author: "Adam Sandler"
+          author: "Bert"
         }) {
           todo {
             id,
@@ -60,15 +59,44 @@ module Mutations
           actual_todo = json["data"]["createTodo"]["todo"]
 
           expect(response).to have_http_status(200)
-          expect(actual_todo["title"]).to eq("Foo")
+          expect(actual_todo["title"]).to eq("Tie my shoes")
           expect(actual_todo["description"]).to eq(nil)
           expect(actual_todo["completed"]).to eq(true)
-          expect(actual_todo["author"]).to eq("Adam Sandler")
+          expect(actual_todo["author"]).to eq("Bert")
+        end
+
+        it "creates a todo with a completion status set to false when one is not provided" do
+          query = <<~GQL
+      mutation{
+        createTodo(input:{
+          title: "Drink water"
+          author: "Ernie"
+        }) {
+          todo {
+            id,
+            title,
+            description,
+            completed,
+            author
+          }
+          errors
+        }
+      }
+      GQL
+
+          expect { post "/graphql", params: {query: query} }.to change(Todo, :count).by(1)
+          actual_todo = json["data"]["createTodo"]["todo"]
+
+          expect(response).to have_http_status(200)
+          expect(actual_todo["title"]).to eq("Drink water")
+          expect(actual_todo["description"]).to eq(nil)
+          expect(actual_todo["completed"]).to eq(false)
+          expect(actual_todo["author"]).to eq("Ernie")
         end
       end
 
       context "when required attributes are not given" do
-        it "does not create a todo and returns an error" do
+        it "does not create a todo without a title and returns an error" do
           query = <<~GQL
       mutation{
         createTodo(input:{
@@ -94,6 +122,63 @@ module Mutations
           expect(response).to have_http_status(200)
           expect(json["createTodo"]).to eq(nil)
           expect(json["errors"][0]["message"]).to eq("Cannot return null for non-nullable field CreateTodoPayload.todo")
+        end
+
+        it "does not create a todo without an author and returns an error" do
+          query = <<~GQL
+      mutation{
+        createTodo(input:{
+          title: "",
+          description: "Lorem Ipsum.",
+          completed: true,
+          author: ""
+        }) {
+          todo {
+            id,
+            title,
+            description,
+            completed,
+            author
+          }
+          errors
+        }
+      }
+      GQL
+
+          expect { post "/graphql", params: {query: query} }.to change(Todo, :count).by(0)
+
+          expect(response).to have_http_status(200)
+          expect(json["createTodo"]).to eq(nil)
+          expect(json["errors"][0]["message"]).to eq("Cannot return null for non-nullable field CreateTodoPayload.todo")
+        end
+
+        it "does not create a todo with invalid fields" do
+          query = <<~GQL
+      mutation{
+        createTodo(input:{
+          title: "Say Hello",
+          snacks: "peaches"
+          description: "Lorem Ipsum.",
+          completed: true,
+          author: "Lisa Kudrow"
+        }) {
+          todo {
+            id,
+            title,
+            description,
+            completed,
+            author
+          }
+          errors
+        }
+      }
+      GQL
+
+          expect { post "/graphql", params: {query: query} }.to change(Todo, :count).by(0)
+
+          expect(response).to have_http_status(200)
+          expect(json["createTodo"]).to eq(nil)
+          expect(json["errors"][0]["message"]).to eq("InputObject 'CreateTodoInput' doesn't accept argument 'snacks'")
         end
       end
     end


### PR DESCRIPTION
## Summary
Adds a default value for description so the user does not have to add the field if they choose not to include a description. It also adds a default value to the completed field. When users create a new todo, they do not have to provide a status; it will automatically be false.