### PR TITLE
Add destroy todo mutation

### DIFF
--- a/app/graphql/mutations/destroy_todo.rb
+++ b/app/graphql/mutations/destroy_todo.rb
@@ -1,0 +1,23 @@
+class Mutations::DestroyTodo < Mutations::BaseMutation
+  null true
+  argument :todo_id, ID, required: true
+
+  field :todo, Types::TodoType, null: false
+  field :errors, [String], null: false
+
+  def resolve(todo_id:)
+    todo = Todo.find(todo_id)
+
+    if todo.destroy
+      {
+        todo: todo,
+        errors: []
+      }
+    else
+      {
+        todo: nil,
+        errors: todo.errors.full_messages
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,7 +2,11 @@ module Types
   class MutationType < Types::BaseObject
     field :create_todo, mutation: Mutations::CreateTodo,
      description: "Adds new todo"
+
     field :update_todo, mutation: Mutations::UpdateTodo,
      description: "Updates a todo"
+
+    field :destroy_todo, mutation:Mutations::DestroyTodo,
+      description: "Removes a todo"
   end
 end 

--- a/spec/graphql/mutations/destroy_todo_spec.rb
+++ b/spec/graphql/mutations/destroy_todo_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+module Mutations
+  RSpec.describe DestroyTodo, type: :request do
+    it "deletes and returns the deleted item" do
+      todo = Todo.create(title: "Meditate", completed: true, author: "Dalai Lama")
+      todo_id = todo.id
+
+      expect { post "/graphql", params: {query: query(todo_id)} }.to change(Todo, :count).by(-1)
+
+      deleted_todo = json["data"]["destroyTodo"]["todo"]
+
+      expect(response).to have_http_status(:success)
+      expect(deleted_todo["title"]).to eq("Meditate")
+      expect(deleted_todo["author"]).to eq("Dalai Lama")
+      expect(deleted_todo["id"]).to eq(todo_id.to_s)
+    end
+
+    it "returns an error when the todo id is not found" do
+      expect { post "/graphql", params: {query: query(25)} }.to change(Todo, :count).by(0)
+
+      expect(response).to have_http_status(:success)
+      expect(json["errors"][0]["message"]).to eq("Couldn't find Todo with 'id'=25")
+    end
+
+    def query(todo_id)
+      <<~GQL
+      mutation{
+        destroyTodo(input:{
+          todoId: #{todo_id}
+        }) {
+          todo {
+            id,
+            title,
+            description,
+            completed,
+            author
+          }
+          errors
+        }
+      }
+    GQL
+    end
+  end
+end


### PR DESCRIPTION
## Summary
The `delete-todo-mutation` branch gives the user the ability to delete a todo by id. If the id is not found, then it returns a human readable error.

Future work: refactor some of the spec files to use a helper function for the graphql query. 