### PR TITLE
Not for merge: Filter by completion status 

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -8,6 +8,9 @@ module Types
       description: "A basic status check to make sure the API and graphiql is working."
     field :all_todos, [Types::TodoType], null: false,
       description: "Returns all todos"
+    field :search_todos_by_status, [Types::TodoType], null: false do
+      argument :completed, Boolean, required: true
+    end
     
     def status
       "OK"
@@ -15,6 +18,10 @@ module Types
 
    def all_todos
     Todo.all
+   end
+
+   def search_todos_by_status(completed:)
+    Todo.where(completed: completed)
    end
   end
 end

--- a/spec/graphql/queries/query_todo_spec.rb
+++ b/spec/graphql/queries/query_todo_spec.rb
@@ -58,5 +58,57 @@ module Queries
         GQL
       end
     end
+
+    describe "searching todos by completion status" do
+      it "will return a list of todos that are completed" do
+        Todo.create(title: "Cut grass", completed: false, author: "Foo")
+        Todo.create(title: "Pull weeds", completed: false, author: "Baz")
+        Todo.create(title: "Make jam", completed: false, author: "Foo")
+        Todo.create(title: "Code", completed: true, author: "FooBar")
+
+        post "/graphql", params: {query: query_status(true)}
+
+        todo_list = json["data"]["searchTodosByStatus"]
+
+        expect(todo_list.count).to eq(1)
+      end
+
+      it "will return a list of todos that are not completed" do
+        Todo.create(title: "Cut grass", completed: false, author: "Foo")
+        Todo.create(title: "Pull weeds", completed: false, author: "Baz")
+        Todo.create(title: "Make jam", completed: false, author: "Foo")
+        Todo.create(title: "Code", completed: true, author: "FooBar")
+
+        post "/graphql", params: {query: query_status(false)}
+
+        todo_list = json["data"]["searchTodosByStatus"]
+
+        expect(todo_list.count).to eq(3)
+      end
+
+      it "will return an error when a non-boolean is passed in" do
+        Todo.create(title: "Cut grass", completed: false, author: "Foo")
+
+        post "/graphql", params: {query: query_status(5)}
+
+        error = json["errors"][0]["message"]
+
+        expect(error).to eq("Argument 'completed' on Field 'searchTodosByStatus' has an invalid value (5). Expected type 'Boolean!'.")
+      end
+
+      def query_status(status)
+        <<~GQL
+        query{
+          searchTodosByStatus(completed: #{status}) {
+            id
+            title
+            description
+            completed
+            author
+          }
+        }
+        GQL
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary 
The `working-filter-by-completion` adds the ability to query by todo status. However, I am unhappy with the code for the following reasons:

1. It would add a new query field to search by: "searchTodosByStatus{ }". This doesn't feel scalable because the next ticket is search_by_author, so I would have to add a new search field for each one. This feels like it violates the open/closed principle.
2. The QueryType class is getting bloated with different resolver functions, an SRP violation. 

This is a working tested solution; however, I didn't feel comfortable deploying it because I believe it will introduce tech debt. 
See `wip-filter-by-completion-status` for my wip potential solution. 

https://graphql-ruby.org/fields/arguments.html