### PR TITLE
Not for Merge: WIP: Query todos using a resolver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.7.2"
 gem "graphql", "~> 1.12"
 gem "graphiql-rails", "~> 1.7"
 gem "listen", "~> 3.3"
+gem "search_object_graphql", "~> 1.0"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem "rails", "~> 6.1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,10 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    search_object (1.2.4)
+    search_object_graphql (1.0.1)
+      graphql (~> 1.8)
+      search_object (~> 1.2.2)
     shoulda-matchers (5.0.0)
       activesupport (>= 5.2.0)
     spinach (0.11.0)
@@ -256,6 +260,7 @@ DEPENDENCIES
   rspec_junit_formatter (~> 0.4.1)
   rubocop-rails (~> 2.11)
   rubocop-rspec (~> 2.4)
+  search_object_graphql (~> 1.0)
   shoulda-matchers (~> 5.0)
   spinach-rails (~> 0.2.1)
   tzinfo-data

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -1,0 +1,4 @@
+module Resolvers
+  class BaseResolver < GraphQL::Schema::Resolver
+  end
+end

--- a/app/graphql/resolvers/base_search_resolver.rb
+++ b/app/graphql/resolvers/base_search_resolver.rb
@@ -1,0 +1,8 @@
+require "search_object"
+require "search_object/plugin/graphql"
+
+module Resolvers
+  class BaseSearchResolver < BaseResolver
+    include SearchObject.module(:graphql)
+  end
+end

--- a/app/graphql/resolvers/todo_search.rb
+++ b/app/graphql/resolvers/todo_search.rb
@@ -1,0 +1,18 @@
+module Resolvers
+  class TodoSearch < Resolvers::BaseSearchResolver
+    type Types::TodoType.connection_type, null: false
+    description "Lists todos"
+
+    scope { Todo.all }
+
+    option :completed, type: types.Boolean, with: :apply_completed_filter
+
+    def apply_completed_filter(scope, value)
+      if value
+        scope.completed
+      else
+        scope.incompleted
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,3 +1,4 @@
+require_relative "../resolvers/todo_resolver"
 module Types
   class QueryType < Types::BaseObject
     # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
@@ -6,15 +7,16 @@ module Types
 
     field :status, String, null: false,
       description: "A basic status check to make sure the API and graphiql is working."
-    field :all_todos, [Types::TodoType], null: false,
-      description: "Returns all todos"
+    field :all_todos, resolver: Resolvers::TodoSearch
+    # field :all_todos, [Types::TodoType], null: false,
+    #   description: "Returns all todos"
     
     def status
       "OK"
     end
 
-   def all_todos
-    Todo.all
-   end
+  #  def all_todos
+  #   Todo.all
+  #  end
   end
 end


### PR DESCRIPTION
##Summary 
The `wip-filter-by-completion-status` branch is incomplete. I was trying to abstract the filter by status logic into a resolver so a user could query allTodos with a filter argument. I believe this is the cleaner solution of the two.  I used an approach from the howtographql docs with support from the railsgraphql docs, and I could not get it working in time. 

Figure 1. Desired query 
<img width="491" alt="Screen Shot 2021-08-12 at 11 58 37 AM" src="https://user-images.githubusercontent.com/43938783/129237796-d0f41491-8bd6-4280-88d3-1e429f1b3b83.png">

Figure 2. Error Response
<img width="540" alt="Screen Shot 2021-08-12 at 12 01 14 PM" src="https://user-images.githubusercontent.com/43938783/129237930-8c40e39f-c6e0-4996-9185-2cf518f2efe5.png">



https://www.howtographql.com/graphql-ruby/7-filtering/
https://graphql-ruby.org/fields/resolvers.html